### PR TITLE
Update _base.scss

### DIFF
--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -8,15 +8,6 @@ summary {
 	display: list-item !important;
 	list-style-type: none; // Prevent list bullets from appearing in browsers that lack native details/summary support (e.g. IE/Edge)
 	list-style-type: disclosure-closed; // Show summary arrows in Firefox 49.0+ and future versions of Blink/Webkit
-	visibility: visible !important;
-}
-
-%details-nested-in-hidden-details {
-	details {
-		summary {
-			display: none !important;
-		}
-	}
 }
 
 details {
@@ -56,48 +47,11 @@ details {
 			}
 		}
 	}
-
-	// Prevent FOUC
-	&:not([open]) {
-		@extend %details-nested-in-hidden-details;
-		visibility: hidden;
-
-		> {
-			// Need details and * to deal with specificity issues
-			details,
-			* {
-				display: none;
-			}
-		}
-	}
-
-	&.alert {
-		&:not([open]) {
-			visibility: visible;
-		}
-	}
-
-	.out {
-		@extend %details-nested-in-hidden-details;
-	}
 }
 
-.tabpanels {
-	> {
-		details {
-			&:not([open]) {
-				visibility: visible;
-			}
-		}
-	}
-}
-
-// Prevent FOUC when polyfill is disabled
 .wb-disable {
 	details {
-		visibility: visible !important;
-
-		> {
+		& > {
 			*:not(summary) {
 				display: block !important;
 			}


### PR DESCRIPTION

## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Change was to remove the legacy CSS code for details/summary for IE11 (which did not support this element) as its no longer required.  The removal was for the display:none and visibility:  visible/hidden styles.

This fixes two issues: 
1. It prevents the focus of the keyboard tab from moving to a hidden tab in desktop if it contains an details element thus violating WCAG SC 2.4.7 (Level AA) Focus Visible.  
2. It allows the user to use Ctrl+F5 to search for a word/phrase inside of a details element and also opens the element if the word/phrase exists.  

## Additional information (optional) / Information additionnelle (optionel)
Documentation:
There is no need for any change to the documentation as it should not change the functionality of the element and it's use state, it only default to it's original HTML5 state which fixes some accessibility and usability issues.

Impact:
The only impact this will have may be for anybody with an unsupported browser that does not support detail elements (Internet Explorer), or very early browser versions.  If there is a desire to support this, a script could be written or a fallback stylesheet could be created.  Otherwise the issue should be minimal.

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».

- [] Create/update documentation /// Créer/mettre à jour la documentation (Not needed)
- [X] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [X] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue (Not needed)

